### PR TITLE
Add basic audio streaming generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,39 @@ if __name__ == "__main__":
             ta.save(f"test-{i}-{audio_idx}.mp3", audio, model.sr)
 ```
 
+## Streaming Example
+
+Audio can also be generated in a streaming fashion using
+`ChatterboxTTS.generate_stream`, which yields audio chunks as they become
+available.
+
+```python
+import torchaudio as ta
+from chatterbox_vllm.tts import ChatterboxTTS
+
+model = ChatterboxTTS.from_pretrained()
+
+stream = model.generate_stream("Streaming response demo")
+for i, chunk in enumerate(stream):
+    ta.save(f"stream-{i}.mp3", chunk, model.sr)
+```
+## WebSocket Streaming API
+
+Run the WebSocket server:
+
+```bash
+python ws_tts_server.py
+```
+
+Then connect with the helper script to verify streaming:
+
+```bash
+python check_ws_stream.py
+```
+
+Each received chunk is saved as `ws-chunk-*.mp3`.
+
+
 # Benchmarks
 
 To run a benchmark, tweak and run `benchmark.py`.

--- a/check_ws_stream.py
+++ b/check_ws_stream.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+
+import websockets
+
+
+async def main():
+    async with websockets.connect("ws://localhost:8765") as ws:
+        await ws.send(json.dumps({"prompt": "streaming test"}))
+        idx = 0
+        while True:
+            message = await ws.recv()
+            if isinstance(message, str) and message == "done":
+                break
+            with open(f"ws-chunk-{idx}.mp3", "wb") as f:
+                f.write(message)
+            idx += 1
+        print(f"received {idx} chunks")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -351,43 +351,50 @@ class ChatterboxTTS:
         )
 
         with torch.inference_mode():
-            generator = self.t3.generate(
-                [
-                    {
-                        "prompt": text,
-                        "multi_modal_data": {"conditionals": [cond_emb]},
-                    }
-                ],
-                sampling_params=sampling_params,
-                stream=True,
-            )
+            request = {
+                "prompt": text,
+                "multi_modal_data": {"conditionals": [cond_emb]},
+            }
+            request_id = str(next(self.t3.request_counter))
+            self.t3.llm_engine.add_request(request_id, request,
+                                           sampling_params)
 
             speech_tokens = torch.tensor([], device="cuda", dtype=torch.long)
             last_len = 0
-            for request_output in generator:
-                token_ids = [t - SPEECH_TOKEN_OFFSET for t in request_output.outputs[0].token_ids]
-                speech_tokens = torch.tensor(token_ids, device="cuda")
-                speech_tokens = drop_invalid_tokens(speech_tokens)
-                speech_tokens = speech_tokens[speech_tokens < 6561]
+            finished = False
+            while not finished and self.t3.llm_engine.has_unfinished_requests():
+                step_outputs = self.t3.llm_engine.step()
+                for request_output in step_outputs:
+                    if request_output.request_id != request_id:
+                        continue
+                    token_ids = [
+                        t - SPEECH_TOKEN_OFFSET
+                        for t in request_output.outputs[0].token_ids
+                    ]
+                    speech_tokens = torch.tensor(token_ids, device="cuda")
+                    speech_tokens = drop_invalid_tokens(speech_tokens)
+                    speech_tokens = speech_tokens[speech_tokens < 6561]
 
-                wav, _ = self.s3gen.inference(
-                    speech_tokens=speech_tokens,
-                    ref_dict=s3gen_ref,
-                    finalize=False,
-                )
-                wav = wav.cpu()
-                if wav.shape[-1] > last_len:
-                    yield wav[:, last_len:]
-                    last_len = wav.shape[-1]
+                    wav, _ = self.s3gen.inference(
+                        speech_tokens=speech_tokens,
+                        ref_dict=s3gen_ref,
+                        finalize=False,
+                    )
+                    wav = wav.cpu()
+                    if wav.shape[-1] > last_len:
+                        yield wav[:, last_len:]
+                        last_len = wav.shape[-1]
 
-            wav, _ = self.s3gen.inference(
-                speech_tokens=speech_tokens,
-                ref_dict=s3gen_ref,
-                finalize=True,
-            )
-            wav = wav.cpu()
-            if wav.shape[-1] > last_len:
-                yield wav[:, last_len:]
+                    if request_output.finished:
+                        wav, _ = self.s3gen.inference(
+                            speech_tokens=speech_tokens,
+                            ref_dict=s3gen_ref,
+                            finalize=True,
+                        )
+                        wav = wav.cpu()
+                        if wav.shape[-1] > last_len:
+                            yield wav[:, last_len:]
+                        finished = True
 
     def shutdown(self):
         del self.t3

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -321,7 +321,74 @@ class ChatterboxTTS:
             print(f"[S3Gen] Wavform Generation time: {s3gen_gen_time:.2f}s")
 
             return results
-        
+
+    def generate_stream(
+        self,
+        prompt: str,
+        audio_prompt_path: Optional[str] = None,
+        exaggeration: float = 0.5,
+        temperature: float = 0.8,
+        max_tokens: int = 1000,
+        top_p: float = 0.8,
+        repetition_penalty: float = 2.0,
+        *args,
+        **kwargs,
+    ):
+        """Yield audio chunks as they are generated for a single prompt."""
+
+        s3gen_ref, cond_emb = self.get_audio_conditionals(audio_prompt_path)
+        cond_emb = self.update_exaggeration(cond_emb, exaggeration)
+
+        text = "[START]" + punc_norm(prompt) + "[STOP]"
+        sampling_params = SamplingParams(
+            temperature=temperature,
+            stop_token_ids=[self.t3_config.stop_speech_token + SPEECH_TOKEN_OFFSET],
+            max_tokens=min(max_tokens, self.max_model_len),
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            *args,
+            **kwargs,
+        )
+
+        with torch.inference_mode():
+            generator = self.t3.generate(
+                [
+                    {
+                        "prompt": text,
+                        "multi_modal_data": {"conditionals": [cond_emb]},
+                    }
+                ],
+                sampling_params=sampling_params,
+                stream=True,
+            )
+
+            speech_tokens = torch.tensor([], device="cuda", dtype=torch.long)
+            last_len = 0
+            for request_output in generator:
+                token_ids = [t - SPEECH_TOKEN_OFFSET for t in request_output.outputs[0].token_ids]
+                speech_tokens = torch.tensor(token_ids, device="cuda")
+                speech_tokens = drop_invalid_tokens(speech_tokens)
+                speech_tokens = speech_tokens[speech_tokens < 6561]
+
+                wav, _ = self.s3gen.inference(
+                    speech_tokens=speech_tokens,
+                    ref_dict=s3gen_ref,
+                    finalize=False,
+                )
+                wav = wav.cpu()
+                if wav.shape[-1] > last_len:
+                    yield wav[:, last_len:]
+                    last_len = wav.shape[-1]
+
+            wav, _ = self.s3gen.inference(
+                speech_tokens=speech_tokens,
+                ref_dict=s3gen_ref,
+                finalize=True,
+            )
+            wav = wav.cpu()
+            if wav.shape[-1] > last_len:
+                yield wav[:, last_len:]
+
     def shutdown(self):
         del self.t3
         torch.cuda.empty_cache()

--- a/ws_tts_server.py
+++ b/ws_tts_server.py
@@ -1,0 +1,39 @@
+import asyncio
+import io
+import json
+
+import torchaudio as ta
+import websockets
+
+from chatterbox_vllm.tts import ChatterboxTTS
+
+
+async def handle_connection(websocket):
+    async for message in websocket:
+        data = json.loads(message)
+        prompt = data.get("prompt", "")
+        audio_prompt = data.get("audio_prompt_path")
+        exaggeration = data.get("exaggeration", 0.5)
+
+        stream = model.generate_stream(
+            prompt,
+            audio_prompt_path=audio_prompt,
+            exaggeration=exaggeration,
+        )
+
+        for chunk in stream:
+            buf = io.BytesIO()
+            ta.save(buf, chunk, model.sr, format="mp3")
+            await websocket.send(buf.getvalue())
+        await websocket.send("done")
+
+
+async def main():
+    global model
+    model = ChatterboxTTS.from_pretrained()
+    async with websockets.serve(handle_connection, "0.0.0.0", 8765):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `generate_stream` to `ChatterboxTTS` for incremental audio generation
- document streaming usage example
- expose streaming over websockets and provide client example

## Testing
- `pytest --ignore=.venv`


------
https://chatgpt.com/codex/tasks/task_e_68c11d8de4f88322bccd92789d7cc518