### PR TITLE
Add WebSocket audio streaming API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ if __name__ == "__main__":
             ta.save(f"test-{i}-{audio_idx}.mp3", audio, model.sr)
 ```
 
+## Streaming
+
+Pass `stream=True` to `generate` to receive audio chunks as soon as they are ready. The generator yields a tuple of the prompt index and a tensor containing the audio segment.
+
+```python
+for idx, chunk in model.generate("Hello world", stream=True):
+    ta.save(f"stream-{idx}.mp3", chunk, model.sr)
+```
+
+## WebSocket API
+
+Run a WebSocket server that streams audio chunks as they are produced:
+
+```
+python -m chatterbox_vllm.ws_server --ckpt-dir /path/to/checkpoints
+```
+
+Clients send a JSON payload like `{ "text": "Hello" }` and receive the sample rate,
+binary audio chunks, and a final `{ "event": "end" }` message.
+
+A lightweight test client and server using a dummy TTS are included:
+
+```
+python tests/test_websocket.py
+```
+
 # Benchmarks
 
 To run a benchmark, tweak and run `benchmark.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "llvmlite>=0.44.0",
     "vllm==0.10.0",
     "gradio",
+    "websockets",
 ]
 
 [project.optional-dependencies]

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Tuple, Any
+from typing import Optional, Union, Tuple, Any, Iterator
 import time
 
 from vllm import LLM, SamplingParams
@@ -217,13 +217,15 @@ class ChatterboxTTS:
         temperature: float = 0.8,
         max_tokens=1000, # Capped at max_model_len
 
+        stream: bool = False,
+
         # From original Chatterbox HF generation args
         top_p=0.8,
         repetition_penalty=2.0,
 
         # Supports anything in https://docs.vllm.ai/en/v0.9.2/api/vllm/index.html?h=samplingparams#vllm.SamplingParams
         *args, **kwargs,
-    ) -> list[any]:
+    ) -> list[any] | Iterator[tuple[int, torch.Tensor]]:
         s3gen_ref, cond_emb = self.get_audio_conditionals(audio_prompt_path)
 
         return self.generate_with_conds(
@@ -233,6 +235,7 @@ class ChatterboxTTS:
             temperature=temperature,
             exaggeration=exaggeration,
             max_tokens=max_tokens,
+            stream=stream,
             top_p=top_p,
             repetition_penalty=repetition_penalty,
             *args, **kwargs
@@ -252,15 +255,31 @@ class ChatterboxTTS:
         # This can be as low as 2 or 3 for faster generation, though the audio quality will degrade substantially.
         diffusion_steps: int = 10,
 
+        stream: bool = False,
+
         # From original Chatterbox HF generation args
         top_p=0.8,
         repetition_penalty=2.0,
 
         # Supports anything in https://docs.vllm.ai/en/v0.9.2/api/vllm/index.html?h=samplingparams#vllm.SamplingParams
         *args, **kwargs,
-    ) -> list[any]:
+    ) -> list[any] | Iterator[tuple[int, torch.Tensor]]:
         if isinstance(prompts, str):
             prompts = [prompts]
+
+        if stream:
+            return self._stream_generate_with_conds(
+                prompts=prompts,
+                s3gen_ref=s3gen_ref,
+                cond_emb=cond_emb,
+                temperature=temperature,
+                exaggeration=exaggeration,
+                max_tokens=max_tokens,
+                diffusion_steps=diffusion_steps,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                *args, **kwargs,
+            )
 
         cond_emb = self.update_exaggeration(cond_emb, exaggeration)
 
@@ -321,7 +340,78 @@ class ChatterboxTTS:
             print(f"[S3Gen] Wavform Generation time: {s3gen_gen_time:.2f}s")
 
             return results
-        
+
+    def _stream_generate_with_conds(
+        self,
+        prompts: list[str],
+        s3gen_ref: dict[str, Any],
+        cond_emb: torch.Tensor,
+        temperature: float,
+        exaggeration: float,
+        max_tokens: int,
+        diffusion_steps: int,
+        top_p: float,
+        repetition_penalty: float,
+        *args,
+        **kwargs,
+    ) -> Iterator[tuple[int, torch.Tensor]]:
+        cond_emb = self.update_exaggeration(cond_emb, exaggeration)
+
+        prompts = ["[START]" + punc_norm(p) + "[STOP]" for p in prompts]
+
+        request_ids = {}
+        requests = []
+        for i, text in enumerate(prompts):
+            rid = f"stream-{i}"
+            request_ids[rid] = i
+            requests.append({
+                "prompt": text,
+                "multi_modal_data": {"conditionals": [cond_emb]},
+                "request_id": rid,
+            })
+
+        generator = self.t3.generate(
+            requests,
+            sampling_params=SamplingParams(
+                temperature=temperature,
+                stop_token_ids=[self.t3_config.stop_speech_token + SPEECH_TOKEN_OFFSET],
+                max_tokens=min(max_tokens, self.max_model_len),
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                *args,
+                **kwargs,
+            ),
+            stream=True,
+        )
+
+        cache_sources: list[Optional[torch.Tensor]] = [None] * len(prompts)
+        prev_lens = [0] * len(prompts)
+
+        with torch.inference_mode():
+            for result in generator:
+                idx = request_ids[result.request_id]
+                output = result.outputs[0]
+                token_ids = output.token_ids
+                new_ids = token_ids[prev_lens[idx]:]
+                prev_lens[idx] = len(token_ids)
+
+                speech_tokens = torch.tensor([
+                    token - SPEECH_TOKEN_OFFSET for token in new_ids
+                ], device="cuda")
+                speech_tokens = drop_invalid_tokens(speech_tokens)
+                speech_tokens = speech_tokens[speech_tokens < 6561]
+
+                finalize = output.finished
+                if len(speech_tokens) > 0 or finalize:
+                    wav, cache_sources[idx] = self.s3gen.inference(
+                        speech_tokens=speech_tokens,
+                        ref_dict=s3gen_ref,
+                        cache_source=cache_sources[idx],
+                        finalize=finalize,
+                        n_timesteps=diffusion_steps,
+                    )
+                    yield idx, wav.cpu()
+
     def shutdown(self):
         del self.t3
         torch.cuda.empty_cache()

--- a/src/chatterbox_vllm/ws_server.py
+++ b/src/chatterbox_vllm/ws_server.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import websockets
+
+if TYPE_CHECKING:  # pragma: no cover - avoid heavy import at runtime
+    from .tts import ChatterboxTTS
+
+
+async def _handle_connection(websocket: websockets.WebSocketServerProtocol, tts: 'ChatterboxTTS') -> None:
+    async for message in websocket:
+        data = json.loads(message)
+        text = data.get("text", "")
+        # Send sample rate so the client knows how to decode chunks
+        await websocket.send(json.dumps({"sr": tts.sr}))
+        for _, chunk in tts.generate(text, stream=True):
+            await websocket.send(chunk.cpu().numpy().astype("float32").tobytes())
+        await websocket.send(json.dumps({"event": "end"}))
+
+
+async def serve_tts(tts: 'ChatterboxTTS', host: str = "0.0.0.0", port: int = 8765) -> None:
+    async def handler(websocket):
+        await _handle_connection(websocket, tts)
+
+    async with websockets.serve(handler, host, port):
+        await asyncio.Future()  # run forever
+
+
+def main() -> None:
+    import argparse
+    from .tts import ChatterboxTTS
+
+    parser = argparse.ArgumentParser(description="Chatterbox vLLM TTS WebSocket server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--ckpt-dir", type=str, default=None, help="Local checkpoint directory")
+    args = parser.parse_args()
+
+    if args.ckpt_dir:
+        tts = ChatterboxTTS.from_local(args.ckpt_dir)
+    else:
+        tts = ChatterboxTTS.from_pretrained()
+    asyncio.run(serve_tts(tts, host=args.host, port=args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+import numpy as np
+import websockets
+
+from chatterbox_vllm.ws_server import serve_tts
+
+
+class FakeTensor:
+    def __init__(self, arr):
+        self.arr = arr
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.arr
+
+
+class DummyTTS:
+    sr = 16000
+
+    def generate(self, prompt: str, stream: bool = False):
+        assert stream
+        for _ in range(2):
+            yield 0, FakeTensor(np.zeros(1600, dtype="float32"))
+
+
+async def run_client():
+    async with websockets.connect("ws://localhost:8765") as ws:
+        await ws.send(json.dumps({"text": "hello"}))
+        msg = await ws.recv()
+        print(msg)
+        chunks = 0
+        while True:
+            msg = await ws.recv()
+            if isinstance(msg, bytes):
+                chunks += 1
+            else:
+                print(msg)
+                break
+        print(f"received {chunks} chunks")
+
+
+async def main():
+    tts = DummyTTS()
+    server_task = asyncio.create_task(serve_tts(tts))
+    await asyncio.sleep(0.1)
+    await run_client()
+    server_task.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Add `chatterbox_vllm.ws_server` for streaming audio over WebSockets
- Document WebSocket usage and add dummy test client
- Include `websockets` dependency

## Testing
- `python -m py_compile src/chatterbox_vllm/ws_server.py tests/test_websocket.py`
- `PYTHONPATH=src python tests/test_websocket.py`


------
https://chatgpt.com/codex/tasks/task_e_68c122e6383883228598955a2fb437f0