### PR TITLE
Add WebSocket audio streaming API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ if __name__ == "__main__":
             ta.save(f"test-{i}-{audio_idx}.mp3", audio, model.sr)
 ```
 
+## Streaming
+
+Pass `stream=True` to `generate` to receive audio chunks as soon as they are ready. The generator yields a tuple of the prompt index and a tensor containing the audio segment.
+
+```python
+for idx, chunk in model.generate("Hello world", stream=True):
+    ta.save(f"stream-{idx}.mp3", chunk, model.sr)
+```
+
+## WebSocket API
+
+Run a WebSocket server that streams audio chunks as they are produced:
+
+```
+python -m chatterbox_vllm.ws_server --ckpt-dir /path/to/checkpoints
+```
+
+Clients send a JSON payload like `{ "text": "Hello" }` and receive the sample rate,
+binary audio chunks, and a final `{ "event": "end" }` message.
+
+A lightweight test client and server using a dummy TTS are included:
+
+```
+python tests/test_websocket.py
+```
+
 # Benchmarks
 
 To run a benchmark, tweak and run `benchmark.py`.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ python -m chatterbox_vllm.ws_server --ckpt-dir /path/to/checkpoints
 Clients send a JSON payload like `{ "text": "Hello" }` and receive the sample rate,
 binary audio chunks, and a final `{ "event": "end" }` message.
 
+To consume the stream from another project, connect to the server (it binds to
+`ws://localhost:8765` by default) and follow the same protocol. Each connection
+should:
+
+1. Send a JSON text frame with the desired text, e.g. `{ "text": "Hi" }`.
+2. Receive a JSON frame containing the sample rate, e.g. `{ "sr": 16000 }`.
+3. Read each subsequent binary frame as a `float32` PCM audio chunk until a
+   final JSON frame `{ "event": "end" }` is emitted.
+
+Example Python client:
+
+```python
+import asyncio, json, websockets
+
+async def tts_request(text: str):
+    uri = "ws://localhost:8765"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"text": text}))
+        sr = json.loads(await ws.recv())["sr"]
+        async for msg in ws:
+            if isinstance(msg, bytes):
+                process_chunk(msg)  # Handle raw float32 audio
+            elif json.loads(msg).get("event") == "end":
+                break
+
+asyncio.run(tts_request("Hello from another project"))
+```
+
 A lightweight test client and server using a dummy TTS are included:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "llvmlite>=0.44.0",
     "vllm==0.10.0",
     "gradio",
+    "websockets",
 ]
 
 [project.optional-dependencies]

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -365,58 +365,57 @@ class ChatterboxTTS:
 
         prompts = ["[START]" + punc_norm(p) + "[STOP]" for p in prompts]
 
-        request_ids = {}
-        requests = []
-        for i, text in enumerate(prompts):
-            rid = f"stream-{i}"
-            request_ids[rid] = i
-            requests.append({
-                "prompt": text,
-                "multi_modal_data": {"conditionals": [cond_emb]},
-                "request_id": rid,
-            })
-
-        generator = self.t3.generate(
-            requests,
-            sampling_params=SamplingParams(
-                temperature=temperature,
-                stop_token_ids=[self.t3_config.stop_speech_token + SPEECH_TOKEN_OFFSET],
-                max_tokens=min(max_tokens, self.max_model_len),
-                top_p=top_p,
-                repetition_penalty=repetition_penalty,
-                *args,
-                **kwargs,
-            ),
-            stream=True,
+        sampling_params = SamplingParams(
+            temperature=temperature,
+            stop_token_ids=[self.t3_config.stop_speech_token + SPEECH_TOKEN_OFFSET],
+            max_tokens=min(max_tokens, self.max_model_len),
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            *args,
+            **kwargs,
         )
+
+        for i, text in enumerate(prompts):
+            self.t3.llm_engine.add_request(
+                str(i),
+                {
+                    "prompt": text,
+                    "multi_modal_data": {"conditionals": [cond_emb]},
+                },
+                sampling_params.clone(),
+            )
 
         cache_sources: list[Optional[torch.Tensor]] = [None] * len(prompts)
         prev_lens = [0] * len(prompts)
 
         with torch.inference_mode():
-            for result in generator:
-                idx = request_ids[result.request_id]
-                output = result.outputs[0]
-                token_ids = output.token_ids
-                new_ids = token_ids[prev_lens[idx]:]
-                prev_lens[idx] = len(token_ids)
+            while self.t3.llm_engine.has_unfinished_requests():
+                step_outputs = self.t3.llm_engine.step()
+                for output in step_outputs:
+                    idx = int(output.request_id)
+                    out = output.outputs[0]
+                    token_ids = out.token_ids
+                    new_ids = token_ids[prev_lens[idx]:]
+                    prev_lens[idx] = len(token_ids)
 
-                speech_tokens = torch.tensor([
-                    token - SPEECH_TOKEN_OFFSET for token in new_ids
-                ], device="cuda")
-                speech_tokens = drop_invalid_tokens(speech_tokens)
-                speech_tokens = speech_tokens[speech_tokens < 6561]
+                    speech_tokens = torch.tensor([
+                        token - SPEECH_TOKEN_OFFSET for token in new_ids
+                    ], device="cuda")
+                    speech_tokens = drop_invalid_tokens(speech_tokens)
+                    speech_tokens = speech_tokens[speech_tokens < 6561]
 
-                finalize = output.finished
-                if len(speech_tokens) > 0 or finalize:
-                    wav, cache_sources[idx] = self.s3gen.inference(
-                        speech_tokens=speech_tokens,
-                        ref_dict=s3gen_ref,
-                        cache_source=cache_sources[idx],
-                        finalize=finalize,
-                        n_timesteps=diffusion_steps,
-                    )
-                    yield idx, wav.cpu()
+                    finalize = out.finished
+                    if len(speech_tokens) > 0 or finalize:
+                        wav, cache_sources[idx] = self.s3gen.inference(
+                            speech_tokens=speech_tokens,
+                            ref_dict=s3gen_ref,
+                            cache_source=cache_sources[idx],
+                            finalize=finalize,
+                            n_timesteps=diffusion_steps,
+                        )
+                        yield idx, wav.cpu()
+
+        torch.cuda.empty_cache()
 
     def shutdown(self):
         del self.t3

--- a/src/chatterbox_vllm/tts.py
+++ b/src/chatterbox_vllm/tts.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Tuple, Any
+from typing import Optional, Union, Tuple, Any, Iterator
 import time
 
 from vllm import LLM, SamplingParams
@@ -83,7 +83,7 @@ class ChatterboxTTS:
         return S3GEN_SR
 
     @classmethod
-    def from_local(cls, ckpt_dir: str | Path, target_device: str = "cuda", 
+    def from_local(cls, ckpt_dir: str | Path, target_device: str = "cuda",
                    max_model_len: int = 1000, compile: bool = False,
                    max_batch_size: int = 10,
 
@@ -91,6 +91,12 @@ class ChatterboxTTS:
                    s3gen_use_fp16: bool = False,
                    **kwargs) -> 'ChatterboxTTS':
         ckpt_dir = Path(ckpt_dir)
+
+        # Ensure vLLM can locate the T3 weights without relying on environment variables
+        model_safetensors_path = Path.cwd() / "t3-model" / "model.safetensors"
+        model_safetensors_path.parent.mkdir(parents=True, exist_ok=True)
+        model_safetensors_path.unlink(missing_ok=True)
+        model_safetensors_path.symlink_to(ckpt_dir / "t3_cfg.safetensors")
 
         t3_config = T3Config()
 
@@ -217,13 +223,15 @@ class ChatterboxTTS:
         temperature: float = 0.8,
         max_tokens=1000, # Capped at max_model_len
 
+        stream: bool = False,
+
         # From original Chatterbox HF generation args
         top_p=0.8,
         repetition_penalty=2.0,
 
         # Supports anything in https://docs.vllm.ai/en/v0.9.2/api/vllm/index.html?h=samplingparams#vllm.SamplingParams
         *args, **kwargs,
-    ) -> list[any]:
+    ) -> list[any] | Iterator[tuple[int, torch.Tensor]]:
         s3gen_ref, cond_emb = self.get_audio_conditionals(audio_prompt_path)
 
         return self.generate_with_conds(
@@ -233,6 +241,7 @@ class ChatterboxTTS:
             temperature=temperature,
             exaggeration=exaggeration,
             max_tokens=max_tokens,
+            stream=stream,
             top_p=top_p,
             repetition_penalty=repetition_penalty,
             *args, **kwargs
@@ -252,15 +261,31 @@ class ChatterboxTTS:
         # This can be as low as 2 or 3 for faster generation, though the audio quality will degrade substantially.
         diffusion_steps: int = 10,
 
+        stream: bool = False,
+
         # From original Chatterbox HF generation args
         top_p=0.8,
         repetition_penalty=2.0,
 
         # Supports anything in https://docs.vllm.ai/en/v0.9.2/api/vllm/index.html?h=samplingparams#vllm.SamplingParams
         *args, **kwargs,
-    ) -> list[any]:
+    ) -> list[any] | Iterator[tuple[int, torch.Tensor]]:
         if isinstance(prompts, str):
             prompts = [prompts]
+
+        if stream:
+            return self._stream_generate_with_conds(
+                prompts=prompts,
+                s3gen_ref=s3gen_ref,
+                cond_emb=cond_emb,
+                temperature=temperature,
+                exaggeration=exaggeration,
+                max_tokens=max_tokens,
+                diffusion_steps=diffusion_steps,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                *args, **kwargs,
+            )
 
         cond_emb = self.update_exaggeration(cond_emb, exaggeration)
 
@@ -321,7 +346,78 @@ class ChatterboxTTS:
             print(f"[S3Gen] Wavform Generation time: {s3gen_gen_time:.2f}s")
 
             return results
-        
+
+    def _stream_generate_with_conds(
+        self,
+        prompts: list[str],
+        s3gen_ref: dict[str, Any],
+        cond_emb: torch.Tensor,
+        temperature: float,
+        exaggeration: float,
+        max_tokens: int,
+        diffusion_steps: int,
+        top_p: float,
+        repetition_penalty: float,
+        *args,
+        **kwargs,
+    ) -> Iterator[tuple[int, torch.Tensor]]:
+        cond_emb = self.update_exaggeration(cond_emb, exaggeration)
+
+        prompts = ["[START]" + punc_norm(p) + "[STOP]" for p in prompts]
+
+        request_ids = {}
+        requests = []
+        for i, text in enumerate(prompts):
+            rid = f"stream-{i}"
+            request_ids[rid] = i
+            requests.append({
+                "prompt": text,
+                "multi_modal_data": {"conditionals": [cond_emb]},
+                "request_id": rid,
+            })
+
+        generator = self.t3.generate(
+            requests,
+            sampling_params=SamplingParams(
+                temperature=temperature,
+                stop_token_ids=[self.t3_config.stop_speech_token + SPEECH_TOKEN_OFFSET],
+                max_tokens=min(max_tokens, self.max_model_len),
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                *args,
+                **kwargs,
+            ),
+            stream=True,
+        )
+
+        cache_sources: list[Optional[torch.Tensor]] = [None] * len(prompts)
+        prev_lens = [0] * len(prompts)
+
+        with torch.inference_mode():
+            for result in generator:
+                idx = request_ids[result.request_id]
+                output = result.outputs[0]
+                token_ids = output.token_ids
+                new_ids = token_ids[prev_lens[idx]:]
+                prev_lens[idx] = len(token_ids)
+
+                speech_tokens = torch.tensor([
+                    token - SPEECH_TOKEN_OFFSET for token in new_ids
+                ], device="cuda")
+                speech_tokens = drop_invalid_tokens(speech_tokens)
+                speech_tokens = speech_tokens[speech_tokens < 6561]
+
+                finalize = output.finished
+                if len(speech_tokens) > 0 or finalize:
+                    wav, cache_sources[idx] = self.s3gen.inference(
+                        speech_tokens=speech_tokens,
+                        ref_dict=s3gen_ref,
+                        cache_source=cache_sources[idx],
+                        finalize=finalize,
+                        n_timesteps=diffusion_steps,
+                    )
+                    yield idx, wav.cpu()
+
     def shutdown(self):
         del self.t3
         torch.cuda.empty_cache()

--- a/src/chatterbox_vllm/ws_server.py
+++ b/src/chatterbox_vllm/ws_server.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import websockets
+
+if TYPE_CHECKING:  # pragma: no cover - avoid heavy import at runtime
+    from .tts import ChatterboxTTS
+
+
+async def _handle_connection(websocket: websockets.WebSocketServerProtocol, tts: 'ChatterboxTTS') -> None:
+    async for message in websocket:
+        data = json.loads(message)
+        text = data.get("text", "")
+        # Send sample rate so the client knows how to decode chunks
+        await websocket.send(json.dumps({"sr": tts.sr}))
+        for _, chunk in tts.generate(text, stream=True):
+            await websocket.send(chunk.cpu().numpy().astype("float32").tobytes())
+        await websocket.send(json.dumps({"event": "end"}))
+
+
+async def serve_tts(tts: 'ChatterboxTTS', host: str = "0.0.0.0", port: int = 8765) -> None:
+    async def handler(websocket):
+        await _handle_connection(websocket, tts)
+
+    async with websockets.serve(handler, host, port):
+        await asyncio.Future()  # run forever
+
+
+def main() -> None:
+    import argparse
+    from .tts import ChatterboxTTS
+
+    parser = argparse.ArgumentParser(description="Chatterbox vLLM TTS WebSocket server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--ckpt-dir", type=str, default=None, help="Local checkpoint directory")
+    args = parser.parse_args()
+
+    if args.ckpt_dir:
+        tts = ChatterboxTTS.from_local(args.ckpt_dir)
+    else:
+        tts = ChatterboxTTS.from_pretrained()
+    asyncio.run(serve_tts(tts, host=args.host, port=args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chatterbox_vllm/ws_server.py
+++ b/src/chatterbox_vllm/ws_server.py
@@ -29,6 +29,13 @@ async def serve_tts(tts: 'ChatterboxTTS', host: str = "0.0.0.0", port: int = 876
 
 def main() -> None:
     import argparse
+    import os
+
+    # Ensure our custom tokenizer remains visible when vLLM launches
+    # its engine. Running without multiprocessing avoids the child
+    # process losing the TokenizerRegistry entries.
+    os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
     from .tts import ChatterboxTTS
 
     parser = argparse.ArgumentParser(description="Chatterbox vLLM TTS WebSocket server")

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,20 +1,28 @@
 import asyncio
 import json
-import numpy as np
 import websockets
 
 from chatterbox_vllm.ws_server import serve_tts
 
 
 class FakeTensor:
-    def __init__(self, arr):
-        self.arr = arr
+    """Minimal tensor-like wrapper returning raw bytes for testing."""
+
+    def __init__(self, data: bytes):
+        self.data = data
 
     def cpu(self):
         return self
 
+    # Emulate the NumPy API used by ws_server without importing numpy
     def numpy(self):
-        return self.arr
+        return self
+
+    def astype(self, _dtype: str):
+        return self
+
+    def tobytes(self):
+        return self.data
 
 
 class DummyTTS:
@@ -22,8 +30,9 @@ class DummyTTS:
 
     def generate(self, prompt: str, stream: bool = False):
         assert stream
+        chunk = b"\x00" * (1600 * 4)  # 1600 float32 samples
         for _ in range(2):
-            yield 0, FakeTensor(np.zeros(1600, dtype="float32"))
+            yield 0, FakeTensor(chunk)
 
 
 async def run_client():

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from contextlib import suppress
 import websockets
 
 from chatterbox_vllm.ws_server import serve_tts
@@ -57,6 +58,8 @@ async def main():
     await asyncio.sleep(0.1)
     await run_client()
     server_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await server_task
 
 
 if __name__ == "__main__":

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+import numpy as np
+import websockets
+
+from chatterbox_vllm.ws_server import serve_tts
+
+
+class FakeTensor:
+    def __init__(self, arr):
+        self.arr = arr
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.arr
+
+
+class DummyTTS:
+    sr = 16000
+
+    def generate(self, prompt: str, stream: bool = False):
+        assert stream
+        for _ in range(2):
+            yield 0, FakeTensor(np.zeros(1600, dtype="float32"))
+
+
+async def run_client():
+    async with websockets.connect("ws://localhost:8765") as ws:
+        await ws.send(json.dumps({"text": "hello"}))
+        msg = await ws.recv()
+        print(msg)
+        chunks = 0
+        while True:
+            msg = await ws.recv()
+            if isinstance(msg, bytes):
+                chunks += 1
+            else:
+                print(msg)
+                break
+        print(f"received {chunks} chunks")
+
+
+async def main():
+    tts = DummyTTS()
+    server_task = asyncio.create_task(serve_tts(tts))
+    await asyncio.sleep(0.1)
+    await run_client()
+    server_task.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Add `chatterbox_vllm.ws_server` for streaming audio over WebSockets
- Document WebSocket usage and add dummy test client
- Include `websockets` dependency
- Symlink T3 weights automatically when loading local checkpoints

## Testing
- `python -m py_compile src/chatterbox_vllm/ws_server.py src/chatterbox_vllm/tts.py tests/test_websocket.py`
- `PYTHONPATH=src python tests/test_websocket.py`


------
https://chatgpt.com/codex/tasks/task_e_68c122e6383883228598955a2fb437f0